### PR TITLE
Assign dispatch fn to a named constant

### DIFF
--- a/dispatch.js
+++ b/dispatch.js
@@ -1,6 +1,6 @@
 const microRoute = require('./')
 
-function dispatch (actions, pattern, methods, handler) {
+const dispatch = (actions, pattern, methods, handler) => {
   if (handler) {
     actions.push({
       handler,


### PR DESCRIPTION
When using this library with a tool like Webpack which mutates the names of functions, this library throws an error: 
```
ReferenceError: dispatch is not defined
```

This fixes that (if there's a better way to fix this, please let me know!)