### PR TITLE
Allow options to be passed to UrlPattern

### DIFF
--- a/dispatch.js
+++ b/dispatch.js
@@ -1,10 +1,10 @@
 const microRoute = require('./')
 
-const dispatch = (actions, pattern, methods, handler) => {
+const dispatch = (actions, pattern, methods, handler, patternOpts) => {
   if (handler) {
     actions.push({
       handler,
-      route: microRoute(pattern, methods, true)
+      route: microRoute(pattern, methods, true, patternOpts)
     })
   }
   const serverCallback = (req, res) => {
@@ -23,4 +23,4 @@ const dispatch = (actions, pattern, methods, handler) => {
   return serverCallback
 }
 
-module.exports = (pattern, methods, handler) => dispatch([], pattern, methods, handler)
+module.exports = (pattern, methods, handler, patternOpts) => dispatch([], pattern, methods, handler, patternOpts)

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const UrlPattern = require('url-pattern')
 const { parse } = require('url')
 
-module.exports = (pattern = '*', methods = '*', parseQuery) => {
-  const urlPattern = new UrlPattern(pattern)
+module.exports = (pattern = '*', methods = '*', parseQuery, patternOpts) => {
+  const urlPattern = new UrlPattern(pattern, patternOpts)
   const alloweMethods = methods !== '*'
     ? Array.isArray(methods) ? methods : methods.split(',')
     : null

--- a/match.js
+++ b/match.js
@@ -1,3 +1,3 @@
 const route = require('./')
 
-module.exports = (req, pattern, methods, parseQuery) => route(pattern, methods, parseQuery)(req)
+module.exports = (req, pattern, methods, parseQuery, patternOpts) => route(pattern, methods, parseQuery, patternOpts)(req)


### PR DESCRIPTION
Allow options to be passed to `UrlPattern`: https://github.com/snd/url-pattern#customize-the-pattern-syntax .

```js
const patternOpts = { segmentNameStartChar: '$' }

match(req, '/foo/$bar', '*', false, patternOpts)

dispatch()
  .dispatch('/foo/$bar', '*', (req) => {...}, patternOpts)
```
